### PR TITLE
deprecate: mark FreeStyle Libre and planned workout functions as deprecated

### DIFF
--- a/lib/terra_flutter_bridge.dart
+++ b/lib/terra_flutter_bridge.dart
@@ -118,12 +118,14 @@ class TerraFlutter {
     })));
   }
 
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<String?> activateGlucoseSensor() async {
     final String? success = await _channel.invokeMethod('activateGlucoseSensor');
     return success;
   }
 
   // only for apple
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<String?> readGlucoseData() async {
     final String? success = await _channel.invokeMethod('readGlucoseData');
     return success;

--- a/lib/terra_flutter_bridge.dart
+++ b/lib/terra_flutter_bridge.dart
@@ -131,6 +131,7 @@ class TerraFlutter {
     return success;
   }
 
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<ListDataMessage?> getPlannedWorkouts(
       Connection connection) async {
     return ListDataMessage.fromJson(Map<String, dynamic>.from(await _channel.invokeMethod('getPlannedWorkouts', {
@@ -138,6 +139,7 @@ class TerraFlutter {
     })));
   }
 
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<SuccessMessage?> deletePlannedWorkout(
       Connection connection, String id) async {
     return SuccessMessage.fromJson(Map<String, dynamic>.from(await _channel.invokeMethod('deletePlannedWorkout', {
@@ -146,6 +148,7 @@ class TerraFlutter {
     })));
   }
 
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<SuccessMessage?> completePlannedWorkout(
       Connection connection, String id, DateTime? at ) async {
     return SuccessMessage.fromJson(Map<String, dynamic>.from(await _channel.invokeMethod('completePlannedWorkout', {
@@ -155,6 +158,7 @@ class TerraFlutter {
     })));
   }
 
+  @Deprecated('This method is deprecated and will be removed in a future release.')
   static Future<SuccessMessage?> postPlannedWorkout(
       Connection connection, TerraPlannedWorkout payload) async {
     return SuccessMessage.fromJson(Map<String, dynamic>.from(await _channel.invokeMethod('postPlannedWorkout', {


### PR DESCRIPTION
## Summary

Adds `@Deprecated` annotations to the following functions in `lib/terra_flutter_bridge.dart`:

### FreeStyle Libre
- `readGlucoseData()`
- `activateGlucoseSensor()`

### Planned Workouts
- `postPlannedWorkout(connection, payload)`
- `getPlannedWorkouts(connection)`
- `deletePlannedWorkout(connection, id)`
- `completePlannedWorkout(connection, id, at)`

No logic changes — annotation only. Dart analyzer will show deprecation warnings for these functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)