### PR TITLE
feat: add setIgnoredSources for Apple Health source filtering

### DIFF
--- a/android/src/main/java/co/tryterra/terra_flutter_bridge/TerraFlutterPlugin.java
+++ b/android/src/main/java/co/tryterra/terra_flutter_bridge/TerraFlutterPlugin.java
@@ -471,6 +471,11 @@ public class TerraFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
             result
         );
         break;
+      case "setIgnoredSources":
+        HashMap<String, Object> ignoredResult = new HashMap<>();
+        ignoredResult.put("success", true);
+        result.success(ignoredResult);
+        break;
       default:
         result.notImplemented();
         break;

--- a/ios/Classes/SwiftTerraFlutterPlugin.swift
+++ b/ios/Classes/SwiftTerraFlutterPlugin.swift
@@ -719,6 +719,11 @@ public class SwiftTerraFlutterPlugin: NSObject, FlutterPlugin {
 
 
 
+	private func setIgnoredSources(sources: [String], result: @escaping FlutterResult) {
+		Terra.setIgnoredSources(sources)
+		result(["success": true])
+	}
+
 	// exposed handler
 	// parse arguments and call appropriate function
 	public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -827,6 +832,9 @@ public class SwiftTerraFlutterPlugin: NSObject, FlutterPlugin {
 					break;
 				case "postPlannedWorkout":
 					postPlannedWorkout(connection: args["connection"] as! String, workout: args["payload"] as! String, result: result)
+					break;
+				case "setIgnoredSources":
+					setIgnoredSources(sources: args["sources"] as? [String] ?? [], result: result)
 					break;
 				default:
 					result(FlutterMethodNotImplemented)

--- a/lib/terra_flutter_bridge.dart
+++ b/lib/terra_flutter_bridge.dart
@@ -164,4 +164,12 @@ class TerraFlutter {
   static Future<Set<String>> getGivenPermissions() async {
     return Set<String>.from(await _channel.invokeMethod('getGivenPermissions'));
   }
+
+  /// iOS only. Filters out HealthKit data from the given bundle identifiers.
+  /// On Android this is a no-op.
+  static Future<void> setIgnoredSources(List<String> sources) async {
+    await _channel.invokeMethod('setIgnoredSources', {
+      "sources": sources
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `TerraFlutter.setIgnoredSources(List<String>)` to the Dart API
- iOS bridge calls `Terra.setIgnoredSources()` from TerraiOS SDK
- Android bridge returns success as a no-op (iOS-only feature)

## Test plan
- [ ] iOS: call `setIgnoredSources(["com.whoop.app"])` after `initTerra`, verify WHOOP-sourced HealthKit data is excluded
- [ ] Android: call `setIgnoredSources`, verify it completes without error
- [ ] Verify method channel name `"setIgnoredSources"` matches across Dart/iOS/Android

Claude conversation: /Users/alex/Documents/terra-support-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)