### PR TITLE
[0.9.2] Bump TerraiOS to ~> 1.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.2
+* Bump TerraiOS SDK to ~> 1.7.7 — planned workout backend sync enabled by default
+
 ## 0.9.1
 * Bump TerraiOS SDK to 1.7.1 (https://github.com/tryterra/TerraiOS/wiki/Change-Log)
 

--- a/ios/terra_flutter_bridge.podspec
+++ b/ios/terra_flutter_bridge.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'terra_flutter_bridge'
-  s.version          = '0.4.3'
+  s.version          = '0.4.4'
   s.summary          = 'Flutter Bridge for TerraiOS.'
   s.description      = <<-DESC
 Flutter Bridge for Terra iOS
@@ -15,7 +15,7 @@ Flutter Bridge for Terra iOS
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TerraiOS', '~> 1.7.1'
+  s.dependency 'TerraiOS', '~> 1.7.7'
   s.frameworks = ['HealthKit']
 
   s.platform = :ios, '13.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terra_flutter_bridge
 description: Terra Flutter bridge to connect to TerraiOS and TerraAndroid.
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/tryterra/terra-flutter
 
 environment:


### PR DESCRIPTION
## Summary
- Bump TerraiOS SDK from ~> 1.7.1 to ~> 1.7.7
- Planned workout backend sync is now enabled by default — no Flutter-side code changes needed