### PR TITLE
Bump android-sdk to 0.0.11 (Samsung permission-cache fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0-samsung.3
+
+* Bump android-sdk (Samsung-direct) to 0.0.11 — fixes empty activity/sleep for already-granted users (https://github.com/tryterra/TerraAndroidLocal/pull/17)
+
 ## 0.6.3
 
 * Bump TerraiOS SDK to 1.6.2 (https://github.com/tryterra/TerraiOS/wiki/Change-Log)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'co.tryterra:android-sdk:0.0.10'
+    implementation 'co.tryterra:android-sdk:0.0.11'
     implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terra_flutter_bridge
 description: Terra Flutter bridge to connect to TerraiOS and TerraAndroid.
-version:  0.9.0-samsung.2
+version:  0.9.0-samsung.3
 homepage: https://github.com/tryterra/terra-flutter
 
 environment:


### PR DESCRIPTION
Bumps `co.tryterra:android-sdk` 0.0.10 → **0.0.11** on the Samsung Flutter bridge, the pubspec version to `0.9.0-samsung.3`, and adds a CHANGELOG entry.

0.0.11 (TerraAndroidLocal PR #17) fixes the Samsung-direct SDK returning empty activity/sleep for users whose permissions were already granted — it now resolves the granted-permissions set per read instead of relying on a stale process-global cache. Verified on a Samsung Health emulator (a recorded workout returned empty on the buggy build, populated after the fix).

Once merged + published to pub.dev, customers on the samsung-tagged Flutter bridge upgrade to pick up the fix.