### PR TITLE
Fix Android initConnection success propagation

### DIFF
--- a/android/src/main/java/co/tryterra/terra_flutter_bridge/TerraFlutterPlugin.java
+++ b/android/src/main/java/co/tryterra/terra_flutter_bridge/TerraFlutterPlugin.java
@@ -211,7 +211,7 @@ public class TerraFlutterPlugin implements FlutterPlugin, MethodCallHandler, Act
       null,
       (success, error)-> {
         HashMap<String, Object> map = new HashMap<>();
-        map.put("success", true);
+        map.put("success", success);
         if (error != null){
           map.put("error", error.getMessage());
         }


### PR DESCRIPTION
## Summary
This PR was generated by the Terra support agent from an ops investigation and needs engineering review.

Android Flutter bridge `initConnection` was always returning `success: true` from the native callback, even when the underlying Android SDK reported `success = false` and returned an error. That caused Flutter callers to treat Samsung init/permission failures as successful, masking permission setup issues in release builds.

## Root cause
In `android/src/main/java/co/tryterra/terra_flutter_bridge/TerraFlutterPlugin.java`, the `initConnection` callback built the result map with a hardcoded `map.put("success", true)` instead of forwarding the native callback boolean.

## Fix
Replace the hardcoded success value with the actual native callback value:
- `map.put("success", success)`

This keeps error propagation unchanged while allowing Flutter apps to detect failed Samsung initialization/permission flows correctly.

## How to test
1. Build an Android app using this plugin and call `initConnection` for Samsung.
2. Exercise a failure path where the native SDK returns `success = false` (for example, deny or interrupt the Samsung permission/init flow, or use a scenario known to fail in release builds).
3. Confirm the Flutter result now returns `success: false` and includes the native error message when present.
4. Confirm a normal successful Samsung init still returns `success: true`.
