### PR TITLE
release: terra_flutter_bridge 0.9.3 (latest native SDKs)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ android {
 
     dependencies {
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
-        implementation 'co.tryterra:terra-android:1.6.3'
+        implementation 'co.tryterra:terra-android:1.7.1'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 }

--- a/ios/terra_flutter_bridge.podspec
+++ b/ios/terra_flutter_bridge.podspec
@@ -15,7 +15,7 @@ Flutter Bridge for Terra iOS
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TerraiOS', '~> 1.7.7'
+  s.dependency 'TerraiOS', '~> 1.7.9'
   s.frameworks = ['HealthKit']
 
   s.platform = :ios, '13.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terra_flutter_bridge
 description: Terra Flutter bridge to connect to TerraiOS and TerraAndroid.
-version: 0.9.2
+version: 0.9.3
 homepage: https://github.com/tryterra/terra-flutter
 
 environment:


### PR DESCRIPTION
Bumps to **0.9.3** and pins **TerraiOS ~> 1.7.9** + **co.tryterra:terra-android 1.7.1**. pub.dev publish is manual (no CI in this repo).