### PR TITLE
ci: pub.dev publishing via GitHub Actions (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to pub.dev
+
+# Publishes terra_flutter_bridge to pub.dev when a version tag is pushed.
+# Auth uses pub.dev's GitHub Actions OIDC — no long-lived token/secret. The
+# package must have "Automated publishing" enabled on pub.dev (Admin tab) with
+# this repository and the tag pattern v{{version}} (e.g. v0.9.3).
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for pub.dev OIDC auth
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - name: Publish
+        run: flutter pub publish --force

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ android {
 
     dependencies {
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.1'
-        implementation 'co.tryterra:terra-android:1.6.3'
+        implementation 'co.tryterra:terra-android:1.7.1'
         implementation 'com.google.code.gson:gson:2.9.0'
     }
 }

--- a/ios/terra_flutter_bridge.podspec
+++ b/ios/terra_flutter_bridge.podspec
@@ -15,7 +15,7 @@ Flutter Bridge for Terra iOS
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'TerraiOS', '~> 1.7.7'
+  s.dependency 'TerraiOS', '~> 1.7.9'
   s.frameworks = ['HealthKit']
 
   s.platform = :ios, '13.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: terra_flutter_bridge
 description: Terra Flutter bridge to connect to TerraiOS and TerraAndroid.
-version: 0.9.2
+version: 0.9.3
 homepage: https://github.com/tryterra/terra-flutter
 
 environment:


### PR DESCRIPTION
Adds CI publishing for terra_flutter_bridge — pushing a `v<version>` tag publishes to pub.dev via GitHub Actions **OIDC** (no token/secret to manage).

**Setup required on pub.dev** (one-time, by a publisher admin): package **Admin → Automated publishing → Enable publishing from GitHub Actions**, set repository `tryterra/terra-flutter` and tag pattern `v{{version}}`. After that, release by tagging `vX.Y.Z` on `main` (matching the pubspec version).